### PR TITLE
fix: show dailyPNL up to 2 decimal points

### DIFF
--- a/src/pages/Dashboard/DashboardDetail.tsx
+++ b/src/pages/Dashboard/DashboardDetail.tsx
@@ -203,7 +203,7 @@ const DashboardDetail = () => {
               <h3>Daily PNL</h3>
               <p>
                 {chartData?.dailyPnlRate > 0 ? "+" : ""}
-                {chartData?.dailyPnlRate}%
+                {chartData?.dailyPnlRate.toFixed(2)}%
               </p>
             </PerformanceItem>
           </PerformanceItemWrapper>


### PR DESCRIPTION
dashboard detail에서 dailyPNL 소수점 2자리까지만 나오게 수정